### PR TITLE
Add insert constraints

### DIFF
--- a/src/vector.h
+++ b/src/vector.h
@@ -107,10 +107,10 @@ public:
   ConstIterator end() const noexcept;
 
   // O(N) strong
-  Iterator insert(ConstIterator pos, const T& value);
+  Iterator insert(ConstIterator pos, const T& value) requires (std::is_copy_assignable_v<T>);
 
   // O(N) strong if move nothrow
-  Iterator insert(ConstIterator pos, T&& value);
+  Iterator insert(ConstIterator pos, T&& value) requires (std::is_move_assignable_v<T>);
 
   // O(N) nothrow(swap)
   Iterator erase(ConstIterator pos);


### PR DESCRIPTION
Ограничения на тип лежащий в векторе ограничиваются `is_nothrow_move_constructible_v || is_copy_constructible_v` , однако этого не всегда хватает методу `insert`. По-хорошему в нём должна быть добавка о том, что тип `is_copy_assignable_v` и `is_move_assignable_v` для соответствующих версий метода. Если их не будет, то вектор допускает монстра вида: